### PR TITLE
Add backend review endpoints

### DIFF
--- a/backend/functions/controllers/review_controller.py
+++ b/backend/functions/controllers/review_controller.py
@@ -1,8 +1,10 @@
 from firebase_functions import https_fn
 from services import review_service
 from utils.auth_utils import get_user_id_from_request
+from utils.helpers import cors_enabled
 import json
 
+@cors_enabled
 def submit_review_controller(request: https_fn.Request):
     if request.method != 'POST':
         return https_fn.Response("Method Not Allowed", status=405)
@@ -30,6 +32,7 @@ def submit_review_controller(request: https_fn.Request):
         print(f"Error submitting review: {e}")
         return https_fn.Response(json.dumps({"error": str(e)}), headers={"Content-Type": "application/json"}, status=500)
 
+@cors_enabled
 def get_reviews_controller(request: https_fn.Request):
     if request.method != 'GET':
         return https_fn.Response("Method Not Allowed", status=405)

--- a/backend/functions/main.py
+++ b/backend/functions/main.py
@@ -1,7 +1,7 @@
 from firebase_functions import https_fn
 from firebase_admin import initialize_app, credentials
 import os
-from controllers import game_controller, user_controller
+from controllers import game_controller, user_controller, review_controller
 from utils.auth_utils import require_auth
 
 # サービスアカウントキーのパスを正しく設定
@@ -64,3 +64,13 @@ def updateCompanion(request: https_fn.Request):
 @require_auth
 def deleteCompanion(request: https_fn.Request):
     return user_controller.delete_companion_controller(request)
+
+
+@https_fn.on_request()
+def submitReview(request: https_fn.Request):
+    return review_controller.submit_review_controller(request)
+
+
+@https_fn.on_request()
+def getReviews(request: https_fn.Request):
+    return review_controller.get_reviews_controller(request)

--- a/backend/functions/utils/auth_utils.py
+++ b/backend/functions/utils/auth_utils.py
@@ -118,3 +118,23 @@ def get_user_from_request(request: https_fn.Request):
     """
     return getattr(request, 'user', None)
 
+
+def get_user_id_from_request(request: https_fn.Request):
+    """リクエストからユーザーIDを取得するヘルパー関数"""
+    # If request has been processed by require_auth, user info is already attached
+    user = get_user_from_request(request)
+    if user and (user.get('sub') or user.get('uid')):
+        return user.get('sub') or user.get('uid')
+
+    # Fallback: manually parse the Authorization header
+    auth_header = request.headers.get('Authorization')
+    if not auth_header or not auth_header.startswith('Bearer '):
+        return None
+
+    token = auth_header.split(' ')[1]
+    decoded_token = verify_token(token)
+    if not decoded_token:
+        return None
+
+    return decoded_token.get('sub') or decoded_token.get('uid')
+


### PR DESCRIPTION
## Summary
- expose submitReview and getReviews Firebase Functions
- add helper to extract user IDs from auth headers
- enable CORS for review controllers

## Testing
- `cd backend/functions && python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a81f05135883219023c6a6451d21c0