### PR TITLE
Ensure Firebase app is initialized

### DIFF
--- a/backend/functions/main.py
+++ b/backend/functions/main.py
@@ -1,0 +1,14 @@
+import firebase_admin
+
+# Ensure the default Firebase app is initialized only once
+try:
+    firebase_admin.get_app()
+except ValueError:
+    firebase_admin.initialize_app()
+
+# Example function using Firebase services
+# In actual deployment, this would expose an HTTPS function or another trigger.
+
+def example_usage():
+    """Placeholder function demonstrating Firebase initialization."""
+    return "Firebase app initialized: {}".format(firebase_admin.get_app().name)


### PR DESCRIPTION
## Summary
- Initialize default Firebase app to prevent runtime errors
- Add placeholder example using the initialized Firebase app

## Testing
- `python -m py_compile backend/functions/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a82187a6108321997bcca2bf17598a